### PR TITLE
Add support for selecting multiple files in FileChooser

### DIFF
--- a/fsaf/src/main/java/com/github/k1rakishou/fsaf/callback/FileMultiSelectChooserCallback.kt
+++ b/fsaf/src/main/java/com/github/k1rakishou/fsaf/callback/FileMultiSelectChooserCallback.kt
@@ -1,0 +1,3 @@
+package com.github.k1rakishou.fsaf.callback
+
+abstract class FileMultiSelectChooserCallback : MultiSelectChooserCallback

--- a/fsaf/src/main/java/com/github/k1rakishou/fsaf/callback/MultiSelectChooserCallback.kt
+++ b/fsaf/src/main/java/com/github/k1rakishou/fsaf/callback/MultiSelectChooserCallback.kt
@@ -1,0 +1,8 @@
+package com.github.k1rakishou.fsaf.callback
+
+import android.net.Uri
+
+interface MultiSelectChooserCallback {
+  fun onResult(uris: List<Uri>)
+  fun onCancel(reason: String)
+}


### PR DESCRIPTION
I needed support for selecting multiple files instead of just 1 file, so I have created a PR with my downstream changes.

Technically I also had to add making it optional to get write access, but I didn't track that back here, just multi-select support.